### PR TITLE
Feat: Update bdk-jvm to 0.29.2

### DIFF
--- a/kotlin/1.balance.main.kts
+++ b/kotlin/1.balance.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * Query an Electrum server for the total balance of a wallet using a descriptor.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 

--- a/kotlin/10.create-tx-from-raw-bytes.main.kts
+++ b/kotlin/10.create-tx-from-raw-bytes.main.kts
@@ -1,12 +1,12 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * Create a Transaction object from raw bytes.
  */
 
 @file:Repository("https://repo.maven.apache.org/maven2/")
 @file:DependsOn("com.google.guava:guava:31.1-jre")
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 import com.google.common.io.BaseEncoding

--- a/kotlin/11.derive-custom-path.main.kts
+++ b/kotlin/11.derive-custom-path.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * Create extended keys using custom derivation paths.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 

--- a/kotlin/12.basic-transaction.main.kts
+++ b/kotlin/12.basic-transaction.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * Create a transaction with an OP_RETURN output.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 
@@ -42,6 +42,6 @@ val (psbt, txDetails) = TxBuilder()
     .finish(wallet)
 
 println("Transaction details: $txDetails")
-wallet.sign(psbt)
+wallet.sign(psbt, null)
 val tx = psbt.extractTx()
 // blockchain.broadcast(tx)

--- a/kotlin/2.blockinfo.main.kts
+++ b/kotlin/2.blockinfo.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * Query an Electrum server for the testnet blockchain height and latest block hash.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 

--- a/kotlin/3.getaddress.main.kts
+++ b/kotlin/3.getaddress.main.kts
@@ -1,16 +1,16 @@
 /**
- * bdk-jvm 0.11.0
+ * bdk-jvm 0.29.2
  *
  * Get an unused address from a wallet.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.11.0")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 
-val descriptor = "wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)"
+val descriptor = Descriptor("wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84h/1h/0h/0/*)", Network.TESTNET)
 val electrumUrl = "ssl://electrum.blockstream.info:60002"
-val blockchainConfig = BlockchainConfig.Electrum(ElectrumConfig(electrumUrl, null, 5u, null, 100u))
+val blockchainConfig = BlockchainConfig.Electrum(ElectrumConfig(electrumUrl, null, 5u, null, 100u, true))
 val blockchain = Blockchain(blockchainConfig)
 val databaseConfig = DatabaseConfig.Memory
 
@@ -24,5 +24,5 @@ val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
 
 wallet.sync(blockchain, LogProgress)
 
-val lastUnusedAddress = wallet.getAddress(AddressIndex.LAST_UNUSED)
+val lastUnusedAddress = wallet.getAddress(AddressIndex.LastUnused)
 println("The last unused address for this wallet is ${lastUnusedAddress.address} at index ${lastUnusedAddress.index}")

--- a/kotlin/3.getaddress.main.kts
+++ b/kotlin/3.getaddress.main.kts
@@ -24,5 +24,5 @@ val wallet = Wallet(descriptor, null, Network.TESTNET, databaseConfig)
 
 wallet.sync(blockchain, LogProgress)
 
-val lastUnusedAddress = wallet.getAddress(AddressIndex.LastUnused)
-println("The last unused address for this wallet is ${lastUnusedAddress.address} at index ${lastUnusedAddress.index}")
+val lastUnusedAddress: AddressInfo = wallet.getAddress(AddressIndex.LastUnused)
+println("The last unused address for this wallet is ${lastUnusedAddress.address.asString()} at index ${lastUnusedAddress.index}")

--- a/kotlin/4.opreturn.main.kts
+++ b/kotlin/4.opreturn.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * Create a transaction with an OP_RETURN output.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 
@@ -40,5 +40,5 @@ val (psbt, txDetails) = TxBuilder()
         .addData(message)
         .finish(wallet)
 
-println("OP_RETURN transaction created: ${wallet.sign(psbt)}")
+println("OP_RETURN transaction created: ${wallet.sign(psbt, null)}")
 println("Transaction details: $txDetails")

--- a/kotlin/5.listunspentutxo.main.kts
+++ b/kotlin/5.listunspentutxo.main.kts
@@ -23,7 +23,7 @@ val blockchain = Blockchain(blockchainConfig)
 wallet.sync(blockchain, null)
 
 val unspentUtxos: List<LocalUtxo> = wallet.listUnspent()
-println("There are ${unspentUtxos.size} number of outputs in this wallet")
+println("There are ${unspentUtxos.size} unspent outputs in this wallet")
 unspentUtxos.forEach {
     println(it)
 }

--- a/kotlin/5.listunspentutxo.main.kts
+++ b/kotlin/5.listunspentutxo.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * List the unspent outputs this wallet controls.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 

--- a/kotlin/6.descriptor-from-mnemonic.main.kts
+++ b/kotlin/6.descriptor-from-mnemonic.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.25.0
+ * bdk-jvm 0.29.2
  *
  * Create a BIP84 descriptor starting from a 12-word mnemonic.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.25.0")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 

--- a/kotlin/7.public-descriptor-template.main.kts
+++ b/kotlin/7.public-descriptor-template.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.26.0
+ * bdk-jvm 0.29.2
  *
  * Create a public descriptor using descriptor templates.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.26.0")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 

--- a/kotlin/8.transaction-details.main.kts
+++ b/kotlin/8.transaction-details.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.26.0
+ * bdk-jvm 0.29.2
  *
  * Print transaction details for each transaction the wallet has completed.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.26.0")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 
@@ -26,7 +26,7 @@ val balance = wallet.getBalance().total
 println("Wallet descriptor is ${descriptor.asStringPrivate()}")
 println("The wallet balance is $balance\n")
 
-val txList: List<TransactionDetails> = wallet.listTransactions()
+val txList: List<TransactionDetails> = wallet.listTransactions(false)
 txList.forEach {
     println("$it \n")
 }

--- a/kotlin/8.transaction-details.main.kts
+++ b/kotlin/8.transaction-details.main.kts
@@ -26,7 +26,7 @@ val balance = wallet.getBalance().total
 println("Wallet descriptor is ${descriptor.asStringPrivate()}")
 println("The wallet balance is $balance\n")
 
-val txList: List<TransactionDetails> = wallet.listTransactions(false)
+val txList: List<TransactionDetails> = wallet.listTransactions(includeRaw = false)
 txList.forEach {
     println("$it \n")
 }

--- a/kotlin/9.private-descriptor-template.main.kts
+++ b/kotlin/9.private-descriptor-template.main.kts
@@ -1,10 +1,10 @@
 /**
- * bdk-jvm 0.27.1
+ * bdk-jvm 0.29.2
  *
  * Create private and public descriptors using descriptor templates.
  */
 
-@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.27.1")
+@file:DependsOn("org.bitcoindevkit:bdk-jvm:0.29.2")
 
 import org.bitcoindevkit.*
 


### PR DESCRIPTION
Tested the PR
Logs:

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 1.balance.main.kts
The wallet balance is 28160

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 2.blockinfo.main.kts
Latest block is block 2442367 with hash 00000000000000034ffd8b5594798fe11f6cded357468e03382b6c26840d4f78

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 3.getaddress.main.kts
The last unused address for this wallet is org.bitcoindevkit.Address@28faece4 at index 11

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 4.opreturn.main.kts   
OP_RETURN transaction created: true
Transaction details: TransactionDetails(transaction=null, fee=392, received=26768, sent=28160, txid=69aa8dc91337e55b67858c197bda64274a7beceb48de83d44761dc1e4d57a294, confirmationTime=null)

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 5.listunspentutxo.main.kts
There are 1 number of outputs in this wallet
LocalUtxo(outpoint=OutPoint(txid=ed76a2c91ebabcb3653a03de0d57d77e6e80ade1e0fa27f6d94f202af3ff2bef, vout=1), txout=TxOut(value=28160, scriptPubkey=org.bitcoindevkit.Script@24d10d40), keychain=EXTERNAL, isSpent=false)

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 6.descriptor-from-mnemonic.main.kts
The descriptor is wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84'/1'/0'/0/*)

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 7.public-descriptor-template.main.kts
The descriptor is wpkh([9122d9e0/84'/1'/0']tpubDCYVtmaSaDzTxcgvoP5AHZNbZKZzrvoNH9KARep88vESc6MxRqAp4LmePc2eeGX6XUxBcdhAmkthWTDqygPz2wLAyHWisD299Lkdrj5egY6/0/*)#zpaanzgu

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 8.transaction-details.main.kts       
Wallet descriptor is wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84'/1'/0'/0/*)#yl0cyza0
The wallet balance is 28160

TransactionDetails(transaction=null, fee=282, received=37436, sent=38718, txid=07dae3e0ae7e2cc8ea77fabf4694eccc72341458529a6c7212284b80ed402b07, confirmationTime=BlockTime(height=2418457, timestamp=1675190522))

TransactionDetails(transaction=null, fee=282, received=33590, sent=34872, txid=063c890a54dd59e8e54418f28131d84a3032e3501a2dcd5e115f3c966b0a1e33, confirmationTime=BlockTime(height=2418457, timestamp=1675190522))

TransactionDetails(transaction=null, fee=286, received=40000, sent=0, txid=1083635084a58c301dd16ce10f8bc9e5c406ab7df26d6e29a360d53a21401e4e, confirmationTime=BlockTime(height=2414931, timestamp=1673023431))

TransactionDetails(transaction=null, fee=282, received=29744, sent=31026, txid=33657aa81ee20dd4513d4817d978edfe2b90c9cc4f529402c9c9de382f2b0a5c, confirmationTime=BlockTime(height=2418457, timestamp=1675190522))

TransactionDetails(transaction=null, fee=282, received=36154, sent=37436, txid=cdb5c4b6ccefa88617bff960dd18e84287f7fe4e725f1845cb2988c2ec27e367, confirmationTime=BlockTime(height=2418457, timestamp=1675190522))

TransactionDetails(transaction=null, fee=282, received=34872, sent=36154, txid=dce6b2395dbb0f0dccbd758afeeacdd6fa417b9ac339ff8b100c8c5d10d7db74, confirmationTime=BlockTime(height=2418457, timestamp=1675190522))

TransactionDetails(transaction=null, fee=282, received=31026, sent=32308, txid=395d0c29f037711835ad0814b78f8f420fd6889c8719bf79d54edf5005e693ae, confirmationTime=BlockTime(height=2418457, timestamp=1675190522))

TransactionDetails(transaction=null, fee=141, received=28803, sent=29744, txid=dd56b1922ef6e695cd33967a6f2ade5c1d273e6ddc8f1377be207c5134f6c2cc, confirmationTime=BlockTime(height=2424259, timestamp=1678733931))

TransactionDetails(transaction=null, fee=282, received=38718, sent=40000, txid=c64e097ce46935a9681b852f977392767aa241db4772b2d41490fe3463b6cae8, confirmationTime=BlockTime(height=2418455, timestamp=1675189771))

TransactionDetails(transaction=null, fee=418, received=28160, sent=28803, txid=ed76a2c91ebabcb3653a03de0d57d77e6e80ade1e0fa27f6d94f202af3ff2bef, confirmationTime=BlockTime(height=2436887, timestamp=1686238896))

TransactionDetails(transaction=null, fee=282, received=32308, sent=33590, txid=9f0cac468d22ade97e07fca03ad13c6adee62c60f6b6d4c0112003b608d971f9, confirmationTime=BlockTime(height=2418457, timestamp=1675190522))


C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 9.private-descriptor-template.main.kts
The descriptor is wpkh(tprv8ZgxMBicQKsPf2qfrEygW6fdYseJDDrVnDv26PH5BHdvSuG6ecCbHqLVof9yZcMoM31z9ur3tTYbSnr1WBqbGX97CbXcmp5H6qeMpyvx35B/84'/1'/0'/0/*)#yl0cyza0
The public descriptor is wpkh([9122d9e0/84'/1'/0']tpubDCYVtmaSaDzTxcgvoP5AHZNbZKZzrvoNH9KARep88vESc6MxRqAp4LmePc2eeGX6XUxBcdhAmkthWTDqygPz2wLAyHWisD299Lkdrj5egY6/0/*)#zpaanzgu

C:\Users\prakh\StudioProjects\bitcoindevkit-scripts\kotlin>kotlin 10.create-tx-from-raw-bytes.main.kts  
[2, 0, 0, 0, 0, 1, 3, 28, 251, 200, 245, 79, 191, 164, 163, 58, 48, 6, 136, 65, 55, 31, 128, 219, 254, 22, 98, 17, 36, 34, 19, 24, 132, 40, 244, 55, 68, 92, 145, 0, 0, 0, 0, 106, 71, 4
8, 68, 2, 32, 111, 188, 236, 141, 45, 46, 116, 13, 130, 77, 61, 54, 204, 52, 91, 55, 217, 246, 93, 102, 90, 153, 245, 189, 92, 158, 141, 66, 39, 10, 3, 168, 2, 32, 19, 149, 150, 50, 73
, 35, 50, 32, 12, 41, 8, 69, 149, 71, 191, 141, 191, 151, 198, 90, 177, 162, 141, 236, 55, 125, 111, 29, 65, 211, 214, 62, 1, 33, 3, 215, 39, 157, 251, 144, 206, 23, 254, 19, 155, 166,
 10, 124, 65, 221, 246, 5, 178, 94, 28, 7, 164, 221, 203, 157, 254, 244, 231, 214, 113, 15, 72, 254, 255, 255, 255, 71, 98, 34, 72, 79, 94, 53, 179, 240, 228, 63, 101, 252, 118, 226, 2
9, 139, 231, 129, 141, 214, 169, 137, 193, 96, 177, 229, 3, 155, 120, 53, 252, 0, 0, 0, 0, 23, 22, 0, 20, 9, 20, 65, 77, 60, 148, 175, 112, 172, 126, 37, 64, 123, 6, 137, 224, 186, 161
, 12, 119, 254, 255, 255, 255, 168, 61, 149, 74, 98, 86, 139, 188, 153, 204, 100, 76, 98, 235, 115, 131, 215, 194, 162, 86, 48, 65, 160, 174, 184, 145, 166, 164, 5, 88, 149, 87, 0, 0, 
0, 0, 23, 22, 0, 20, 121, 93, 4, 204, 45, 79, 49, 72, 13, 154, 55, 16, 153, 63, 189, 128, 208, 67, 1, 223, 254, 255, 255, 255, 6, 254, 247, 47, 0, 0, 0, 0, 0, 23, 169, 20, 118, 253, 11
2, 53, 205, 38, 241, 163, 42, 90, 185, 121, 224, 86, 113, 58, 172, 37, 121, 104, 135, 165, 0, 15, 0, 0, 0, 0, 0, 25, 118, 169, 20, 184, 51, 45, 80, 42, 82, 149, 113, 198, 175, 75, 230,
 99, 153, 205, 51, 55, 144, 113, 197, 136, 172, 63, 218, 5, 0, 0, 0, 0, 0, 25, 118, 169, 20, 252, 29, 105, 47, 141, 225, 10, 227, 50, 149, 240, 144, 190, 165, 254, 73, 82, 125, 151, 92
, 136, 172, 82, 46, 27, 0, 0, 0, 0, 0, 25, 118, 169, 20, 128, 132, 6, 181, 77, 16, 68, 196, 41, 172, 84, 192, 225, 137, 176, 216, 6, 22, 103, 224, 136, 172, 110, 182, 133, 1, 0, 0, 0, 
0, 25, 118, 169, 20, 223, 171, 96, 133, 243, 168, 251, 62, 103, 16, 32, 106, 90, 149, 147, 19, 197, 97, 143, 77, 136, 172, 187, 162, 0, 0, 0, 0, 0, 0, 25, 118, 169, 20, 235, 48, 38, 85
, 45, 126, 63, 48, 115, 69, 125, 11, 238, 93, 71, 87, 222, 72, 22, 13, 136, 172, 0, 2, 72, 48, 69, 2, 33, 0, 190, 226, 75, 99, 33, 41, 57, 211, 61, 81, 62, 118, 123, 199, 147, 0, 5, 31
, 122, 13, 67, 60, 63, 207, 30, 14, 59, 240, 59, 158, 177, 215, 2, 32, 88, 141, 196, 90, 156, 227, 169, 57, 16, 59, 68, 89, 206, 71, 80, 11, 100, 226, 58, 177, 24, 223, 192, 60, 156, 1
70, 125, 107, 252, 50, 185, 198, 1, 33, 3, 84, 253, 128, 50, 141, 160, 249, 174, 110, 239, 43, 58, 129, 247, 79, 154, 111, 102, 118, 31, 173, 249, 111, 29, 29, 34, 177, 253, 104, 69, 1
35, 100, 2, 72, 48, 69, 2, 33, 0, 226, 156, 126, 58, 94, 252, 16, 218, 98, 105, 229, 252, 32, 182, 161, 203, 139, 235, 146, 19, 12, 197, 44, 103, 228, 110, 244, 10, 170, 92, 172, 95, 2
, 32, 100, 77, 209, 176, 73, 114, 125, 153, 26, 236, 233, 138, 16, 85, 99, 65, 110, 16, 165, 172, 66, 33, 171, 172, 125, 22, 147, 24, 66, 213, 195, 34, 1, 33, 3, 150, 11, 135, 65, 45, 110, 22, 159, 48, 225, 33, 6, 189, 247, 1, 34, 170, 187, 158, 182, 31, 69, 85, 24, 50, 42, 24, 185, 32, 164, 223, 168, 135, 211, 7, 0]
